### PR TITLE
Guard xai debug logs

### DIFF
--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -45,7 +45,6 @@ func newOpenAIClient(opts providerClientOptions) OpenAIClient {
 	for _, o := range opts.openaiOptions {
 		o(&openaiOpts)
 	}
-	
 
 	openaiClientOptions := []option.RequestOption{}
 	if opts.apiKey != "" {
@@ -207,12 +206,12 @@ func (o *openaiClient) sendWithParams(ctx context.Context, params openai.ChatCom
 		baseURL = o.options.baseURL
 	}
 	request.SetCurrent(string(o.providerOptions.model.Provider), o.providerOptions.model.APIModel, baseURL)
-	
+
 	cfg := config.Get()
 	if cfg.Debug {
 		jsonData, _ := json.Marshal(params)
 		logging.Debug("Prepared messages", "messages", string(jsonData))
-		
+
 		// Log request info to file
 		o.logRequest()
 	}
@@ -281,12 +280,12 @@ func (o *openaiClient) streamWithParams(ctx context.Context, params openai.ChatC
 		baseURL = o.options.baseURL
 	}
 	request.SetCurrent(string(o.providerOptions.model.Provider), o.providerOptions.model.APIModel, baseURL)
-	
+
 	cfg := config.Get()
 	if cfg.Debug {
 		jsonData, _ := json.Marshal(params)
 		logging.Debug("Prepared messages", "messages", string(jsonData))
-		
+
 		// Log request info to file
 		o.logRequest()
 	}
@@ -297,17 +296,17 @@ func (o *openaiClient) streamWithParams(ctx context.Context, params openai.ChatC
 	go func() {
 		for {
 			attempts++
-			
+
 			// Debug logging for xAI
-			if o.options.baseURL == "https://api.x.ai/v1" {
-				debugFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-				if debugFile != nil {
-					fmt.Fprintf(debugFile, "[%s] OpenAI client: Starting stream attempt %d\n", 
+			if o.options.baseURL == "https://api.x.ai/v1" && o.isDebugMode() {
+				debugFile, err := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+				if err == nil {
+					fmt.Fprintf(debugFile, "[%s] OpenAI client: Starting stream attempt %d\n",
 						time.Now().Format("2006-01-02 15:04:05.000"), attempts)
 					debugFile.Close()
 				}
 			}
-			
+
 			openaiStream := o.client.Chat.Completions.NewStreaming(
 				ctx,
 				params,
@@ -333,28 +332,28 @@ func (o *openaiClient) streamWithParams(ctx context.Context, params openai.ChatC
 			}
 
 			err := openaiStream.Err()
-			
+
 			// Debug logging for xAI
-			if o.options.baseURL == "https://api.x.ai/v1" {
-				debugFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-				if debugFile != nil {
+			if o.options.baseURL == "https://api.x.ai/v1" && o.isDebugMode() {
+				debugFile, errOpen := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+				if errOpen == nil {
 					if err != nil {
-						fmt.Fprintf(debugFile, "[%s] OpenAI client: Stream error: %v\n", 
+						fmt.Fprintf(debugFile, "[%s] OpenAI client: Stream error: %v\n",
 							time.Now().Format("2006-01-02 15:04:05.000"), err)
 						// Try to get more details about the error
 						var apierr *openai.Error
 						if errors.As(err, &apierr) {
-							fmt.Fprintf(debugFile, "[%s] OpenAI client: API Error - Status: %d, Message: %s\n", 
+							fmt.Fprintf(debugFile, "[%s] OpenAI client: API Error - Status: %d, Message: %s\n",
 								time.Now().Format("2006-01-02 15:04:05.000"), apierr.StatusCode, apierr.Message)
 						}
 					} else {
-						fmt.Fprintf(debugFile, "[%s] OpenAI client: Stream completed successfully\n", 
+						fmt.Fprintf(debugFile, "[%s] OpenAI client: Stream completed successfully\n",
 							time.Now().Format("2006-01-02 15:04:05.000"))
 					}
 					debugFile.Close()
 				}
 			}
-			
+
 			if err == nil || errors.Is(err, io.EOF) {
 				// Stream completed successfully
 				finishReason := o.finishReason(string(acc.ChatCompletion.Choices[0].FinishReason))
@@ -381,17 +380,17 @@ func (o *openaiClient) streamWithParams(ctx context.Context, params openai.ChatC
 
 			// If there is an error we are going to see if we can retry the call
 			retry, after, retryErr := o.shouldRetry(attempts, err)
-			
+
 			// Debug logging for xAI
-			if o.options.baseURL == "https://api.x.ai/v1" {
-				debugFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-				if debugFile != nil {
-					fmt.Fprintf(debugFile, "[%s] OpenAI client: shouldRetry returned: retry=%v, after=%d, retryErr=%v\n", 
+			if o.options.baseURL == "https://api.x.ai/v1" && o.isDebugMode() {
+				debugFile, errOpen := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+				if errOpen == nil {
+					fmt.Fprintf(debugFile, "[%s] OpenAI client: shouldRetry returned: retry=%v, after=%d, retryErr=%v\n",
 						time.Now().Format("2006-01-02 15:04:05.000"), retry, after, retryErr)
 					debugFile.Close()
 				}
 			}
-			
+
 			if retryErr != nil {
 				request.Clear() // Clear request info on error
 				eventChan <- ProviderEvent{Type: EventError, Error: retryErr}
@@ -513,6 +512,12 @@ func WithReasoningEffort(effort string) OpenAIOption {
 	}
 }
 
+// isDebugMode returns true if global debug is enabled.
+func (o *openaiClient) isDebugMode() bool {
+	cfg := config.Get()
+	return cfg != nil && cfg.Debug
+}
+
 // logRequest logs request information to the debug log
 func (o *openaiClient) logRequest() {
 	cfg := config.Get()
@@ -521,13 +526,13 @@ func (o *openaiClient) logRequest() {
 		debugFile, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if debugFile != nil {
 			defer debugFile.Close()
-			
+
 			// Determine the actual URL being used
 			baseURL := "https://api.openai.com/v1"
 			if o.options.baseURL != "" {
 				baseURL = o.options.baseURL
 			}
-			
+
 			fmt.Fprintf(debugFile, "[%s] Provider: %s, Model: %s, URL: %s\n",
 				time.Now().Format("15:04:05"),
 				o.providerOptions.model.Provider,

--- a/internal/llm/provider/xai.go
+++ b/internal/llm/provider/xai.go
@@ -53,7 +53,7 @@ func newXAIClient(opts providerClientOptions) XAIClient {
 		reasoningEffort: "medium",
 		baseURL:         "https://api.x.ai/v1",
 	}
-	
+
 	for _, o := range opts.openaiOptions {
 		o(&openaiOpts)
 	}
@@ -81,7 +81,7 @@ func (x *xaiClient) convertMessages(messages []message.Message) []openai.ChatCom
 	if externalPrompt := x.loadExternalGrokPrompt(); externalPrompt != "" {
 		x.providerOptions.systemMessage = externalPrompt
 	}
-	
+
 	// Call the parent implementation
 	return x.openaiClient.convertMessages(messages)
 }
@@ -89,27 +89,27 @@ func (x *xaiClient) convertMessages(messages []message.Message) []openai.ChatCom
 func (x *xaiClient) loadExternalGrokPrompt() string {
 	// Search for the prompt file in the same locations as .opencode.json
 	possiblePaths := []string{}
-	
+
 	if homeDir, err := os.UserHomeDir(); err == nil {
 		// 1. $HOME/.opencode/grok4-system-prompt.md
 		possiblePaths = append(possiblePaths, filepath.Join(homeDir, ".opencode", "grok4-system-prompt.md"))
-		
+
 		// 2. $XDG_CONFIG_HOME/opencode/grok4-system-prompt.md
 		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
 			possiblePaths = append(possiblePaths, filepath.Join(xdgConfigHome, "opencode", "grok4-system-prompt.md"))
 		}
-		
+
 		// 3. $HOME/.config/opencode/grok4-system-prompt.md
 		possiblePaths = append(possiblePaths, filepath.Join(homeDir, ".config", "opencode", "grok4-system-prompt.md"))
 	}
-	
+
 	// Try each path in order
 	for _, path := range possiblePaths {
 		if content, err := os.ReadFile(path); err == nil {
 			return string(content)
 		}
 	}
-	
+
 	return ""
 }
 
@@ -118,7 +118,7 @@ func (x *xaiClient) isErrorContent(content string) bool {
 	if content == "" {
 		return false
 	}
-	
+
 	lowerContent := strings.ToLower(content)
 	for _, pattern := range xaiErrorPatterns {
 		if strings.Contains(lowerContent, pattern) {
@@ -144,7 +144,7 @@ func (x *xaiClient) preparedParams(messages []openai.ChatCompletionMessageParamU
 	// xAI doesn't support reasoning_effort parameter, but Grok-4 is always in reasoning mode
 	// Use MaxTokens instead of MaxCompletionTokens for xAI
 	params.MaxTokens = openai.Int(x.providerOptions.maxTokens)
-	
+
 	// xAI API doesn't support these parameters - they remain unset (nil)
 	// - PresencePenalty
 	// - FrequencyPenalty
@@ -158,14 +158,14 @@ func (x *xaiClient) preparedParams(messages []openai.ChatCompletionMessageParamU
 func (x *xaiClient) send(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (*ProviderResponse, error) {
 	// Set current request info for display
 	request.SetCurrent(string(x.providerOptions.model.Provider), x.providerOptions.model.APIModel, "https://api.x.ai/v1")
-	
+
 	// Convert messages and tools
 	openaiMessages := x.convertMessages(messages)
 	openaiTools := x.convertTools(tools)
-	
+
 	// Use our custom preparedParams that filters out unsupported parameters
 	params := x.preparedParams(openaiMessages, openaiTools)
-	
+
 	// Use our custom sendWithParams that detects content-based errors
 	response, err := x.sendWithParams(ctx, params)
 	if err != nil {
@@ -182,7 +182,7 @@ func (x *xaiClient) send(ctx context.Context, messages []message.Message, tools 
 func (x *xaiClient) sendWithParams(ctx context.Context, params openai.ChatCompletionNewParams) (*ProviderResponse, error) {
 	// Call the parent implementation
 	response, err := x.openaiClient.sendWithParams(ctx, params)
-	
+
 	// Check for content-based errors even on successful responses
 	if err == nil && response != nil && x.isErrorContent(response.Content) {
 		// Log the content error
@@ -191,11 +191,11 @@ func (x *xaiClient) sendWithParams(ctx context.Context, params openai.ChatComple
 			Content:    response.Content,
 		}
 		x.logError(contentErr, params)
-		
+
 		// Convert to error that can trigger retry
 		return nil, contentErr
 	}
-	
+
 	return response, err
 }
 
@@ -203,26 +203,28 @@ func (x *xaiClient) sendWithParams(ctx context.Context, params openai.ChatComple
 func (x *xaiClient) stream(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan ProviderEvent {
 	// Set current request info for display
 	request.SetCurrent(string(x.providerOptions.model.Provider), x.providerOptions.model.APIModel, "https://api.x.ai/v1")
-	
+
 	// Debug logging
-	logFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if logFile != nil {
-		fmt.Fprintf(logFile, "\n[%s] ========== STREAM REQUEST STARTED ==========\n", time.Now().Format("2006-01-02 15:04:05.000"))
-		fmt.Fprintf(logFile, "[%s] Model: %s\n", time.Now().Format("2006-01-02 15:04:05.000"), x.providerOptions.model.APIModel)
-		fmt.Fprintf(logFile, "[%s] Number of messages: %d\n", time.Now().Format("2006-01-02 15:04:05.000"), len(messages))
-		logFile.Close()
+	if x.isDebugMode() {
+		logFile, err := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err == nil {
+			fmt.Fprintf(logFile, "\n[%s] ========== STREAM REQUEST STARTED ==========\n", time.Now().Format("2006-01-02 15:04:05.000"))
+			fmt.Fprintf(logFile, "[%s] Model: %s\n", time.Now().Format("2006-01-02 15:04:05.000"), x.providerOptions.model.APIModel)
+			fmt.Fprintf(logFile, "[%s] Number of messages: %d\n", time.Now().Format("2006-01-02 15:04:05.000"), len(messages))
+			logFile.Close()
+		}
 	}
-	
+
 	// Convert messages and tools
 	openaiMessages := x.convertMessages(messages)
 	openaiTools := x.convertTools(tools)
-	
+
 	// Use our custom preparedParams that filters out unsupported parameters
 	params := x.preparedParams(openaiMessages, openaiTools)
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{
 		IncludeUsage: openai.Bool(true),
 	}
-	
+
 	// Use our custom streamWithParams that includes retry logic
 	// This will handle retries for both HTTP errors and content errors
 	return x.streamWithParams(ctx, params)
@@ -231,21 +233,27 @@ func (x *xaiClient) stream(ctx context.Context, messages []message.Message, tool
 // wrapStreamEvents monitors streaming responses for error patterns
 func (x *xaiClient) wrapStreamEvents(baseEvents <-chan ProviderEvent) <-chan ProviderEvent {
 	wrappedEvents := make(chan ProviderEvent)
-	
+
 	go func() {
 		defer close(wrappedEvents)
 		var accumulatedContent strings.Builder
 		var bufferedEvents []ProviderEvent
 		var isBuffering bool
-		
+
 		// Raw logging for debugging
-		logFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		if logFile != nil {
-			defer logFile.Close()
-			fmt.Fprintf(logFile, "\n[%s] ========== NEW STREAM ==========\n", time.Now().Format("2006-01-02 15:04:05.000"))
-			fmt.Fprintf(logFile, "[%s] wrapStreamEvents: Started processing baseEvents\n", time.Now().Format("2006-01-02 15:04:05.000"))
+		var logFile *os.File
+		if x.isDebugMode() {
+			var err error
+			logFile, err = os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err == nil {
+				defer logFile.Close()
+				fmt.Fprintf(logFile, "\n[%s] ========== NEW STREAM ==========\n", time.Now().Format("2006-01-02 15:04:05.000"))
+				fmt.Fprintf(logFile, "[%s] wrapStreamEvents: Started processing baseEvents\n", time.Now().Format("2006-01-02 15:04:05.000"))
+			} else {
+				logFile = nil
+			}
 		}
-		
+
 		eventCount := 0
 		for event := range baseEvents {
 			eventCount++
@@ -261,27 +269,27 @@ func (x *xaiClient) wrapStreamEvents(baseEvents <-chan ProviderEvent) <-chan Pro
 					fmt.Fprintf(logFile, "  Error: %v\n", event.Error)
 				}
 			}
-			
+
 			switch event.Type {
 			case EventContentDelta:
 				// Always buffer content deltas initially
 				accumulatedContent.WriteString(event.Content)
 				bufferedEvents = append(bufferedEvents, event)
 				isBuffering = true
-				
+
 				// Don't forward any deltas until we know it's not an error
-				
+
 			case EventComplete:
 				fullContent := accumulatedContent.String()
 				if event.Response != nil {
 					fullContent = event.Response.Content
 				}
-				
+
 				if logFile != nil {
 					fmt.Fprintf(logFile, "[%s] Accumulated Content: %q\n", time.Now().Format("2006-01-02 15:04:05.000"), fullContent)
 					fmt.Fprintf(logFile, "[%s] Is Error Content: %v\n", time.Now().Format("2006-01-02 15:04:05.000"), x.isErrorContent(fullContent))
 				}
-				
+
 				if x.isErrorContent(fullContent) {
 					// Don't forward any buffered events - convert to error
 					wrappedEvents <- ProviderEvent{
@@ -302,31 +310,31 @@ func (x *xaiClient) wrapStreamEvents(baseEvents <-chan ProviderEvent) <-chan Pro
 					// No buffered events, just forward complete
 					wrappedEvents <- event
 				}
-				
+
 				// Reset for next message
 				accumulatedContent.Reset()
 				bufferedEvents = nil
 				isBuffering = false
-				
+
 			case EventError:
 				// Clear any buffered events on error
 				accumulatedContent.Reset()
 				bufferedEvents = nil
 				isBuffering = false
 				wrappedEvents <- event
-				
+
 			default:
 				// Forward other events immediately (tool calls, etc)
 				wrappedEvents <- event
 			}
 		}
-		
+
 		// Log stream completion
 		if logFile != nil {
-			fmt.Fprintf(logFile, "[%s] wrapStreamEvents: Finished processing %d events from baseEvents\n", 
+			fmt.Fprintf(logFile, "[%s] wrapStreamEvents: Finished processing %d events from baseEvents\n",
 				time.Now().Format("2006-01-02 15:04:05.000"), eventCount)
 		}
-		
+
 		// If stream ended with buffered events (shouldn't happen normally)
 		if len(bufferedEvents) > 0 && !x.isErrorContent(accumulatedContent.String()) {
 			for _, bufferedEvent := range bufferedEvents {
@@ -334,7 +342,7 @@ func (x *xaiClient) wrapStreamEvents(baseEvents <-chan ProviderEvent) <-chan Pro
 			}
 		}
 	}()
-	
+
 	return wrappedEvents
 }
 
@@ -346,23 +354,23 @@ func (x *xaiClient) shouldRetry(attempts int, err error) (bool, int64, error) {
 		if attempts > maxRetries {
 			return false, 0, fmt.Errorf("maximum retry attempts reached for xAI rate limit: %d retries", maxRetries)
 		}
-		
+
 		// Use exponential backoff with jitter
 		backoffMs := 2000 * (1 << (attempts - 1))
 		jitterMs := int(float64(backoffMs) * 0.2)
 		retryMs := backoffMs + jitterMs
-		
+
 		// Log the retry attempt
 		logging.WarnPersist(
-			fmt.Sprintf("xAI content error detected: %s. Retrying... attempt %d of %d", 
+			fmt.Sprintf("xAI content error detected: %s. Retrying... attempt %d of %d",
 				strings.TrimSpace(xaiErr.Content), attempts, maxRetries),
-			logging.PersistTimeArg, 
+			logging.PersistTimeArg,
 			time.Millisecond*time.Duration(retryMs+100),
 		)
-		
+
 		return true, int64(retryMs), nil
 	}
-	
+
 	// Check for OpenAI API errors
 	var apierr *openai.Error
 	if errors.As(err, &apierr) {
@@ -372,7 +380,7 @@ func (x *xaiClient) shouldRetry(attempts int, err error) (bool, int64, error) {
 			return false, 0, fmt.Errorf("xAI quota exceeded: %s", err.Error())
 		}
 	}
-	
+
 	// Fall back to OpenAI's shouldRetry for standard errors
 	return x.openaiClient.shouldRetry(attempts, err)
 }
@@ -381,28 +389,28 @@ func (x *xaiClient) shouldRetry(attempts int, err error) (bool, int64, error) {
 // We completely replace the parent implementation to control retry logic
 func (x *xaiClient) streamWithParams(ctx context.Context, params openai.ChatCompletionNewParams) <-chan ProviderEvent {
 	eventChan := make(chan ProviderEvent)
-	
+
 	go func() {
 		defer close(eventChan)
 		attempts := 0
-		
+
 		for {
 			attempts++
-			
+
 			// Create a new stream directly
 			openaiStream := x.client.Chat.Completions.NewStreaming(ctx, params)
-			
+
 			acc := openai.ChatCompletionAccumulator{}
 			currentContent := ""
 			toolCalls := make([]message.ToolCall, 0)
 			hasError := false
 			var streamErr error
-			
+
 			// Process stream chunks
 			for openaiStream.Next() {
 				chunk := openaiStream.Current()
 				acc.AddChunk(chunk)
-				
+
 				for _, choice := range chunk.Choices {
 					if choice.Delta.Content != "" {
 						eventChan <- ProviderEvent{
@@ -413,48 +421,54 @@ func (x *xaiClient) streamWithParams(ctx context.Context, params openai.ChatComp
 					}
 				}
 			}
-			
+
 			// Check for error
 			streamErr = openaiStream.Err()
 			if streamErr != nil && !errors.Is(streamErr, io.EOF) {
 				hasError = true
-				
+
 				// Log the error
-				logFile, _ := os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-				if logFile != nil {
-					fmt.Fprintf(logFile, "[%s] xAI streamWithParams: Error on attempt %d: %v\n", 
-						time.Now().Format("2006-01-02 15:04:05.000"), attempts, streamErr)
-					logFile.Close()
+				var logFile *os.File
+				var err error
+				if x.isDebugMode() {
+					logFile, err = os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+					if err == nil {
+						fmt.Fprintf(logFile, "[%s] xAI streamWithParams: Error on attempt %d: %v\n",
+							time.Now().Format("2006-01-02 15:04:05.000"), attempts, streamErr)
+						logFile.Close()
+					}
 				}
-				
+
 				// Check if we should retry using our custom logic
 				retry, after, retryErr := x.shouldRetry(attempts, streamErr)
-				
+
 				// Log retry decision
-				logFile, _ = os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-				if logFile != nil {
-					fmt.Fprintf(logFile, "[%s] xAI streamWithParams: shouldRetry returned: retry=%v, after=%d, retryErr=%v\n", 
-						time.Now().Format("2006-01-02 15:04:05.000"), retry, after, retryErr)
-					logFile.Close()
+				if x.isDebugMode() {
+					logFile, err = os.OpenFile("/tmp/xai-stream-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+					if err == nil {
+						fmt.Fprintf(logFile, "[%s] xAI streamWithParams: shouldRetry returned: retry=%v, after=%d, retryErr=%v\n",
+							time.Now().Format("2006-01-02 15:04:05.000"), retry, after, retryErr)
+						logFile.Close()
+					}
 				}
-				
+
 				if retryErr != nil {
 					request.Clear()
 					eventChan <- ProviderEvent{Type: EventError, Error: retryErr}
 					return
 				}
-				
+
 				if retry {
 					// Show retry message
 					logging.WarnPersist(
 						fmt.Sprintf("Retrying due to rate limit... attempt %d of %d", attempts, maxRetries),
-						logging.PersistTimeArg, 
+						logging.PersistTimeArg,
 						time.Millisecond*time.Duration(after+100),
 					)
-					
+
 					// Clear request info during retry
 					request.Clear()
-					
+
 					// Wait before retrying
 					select {
 					case <-ctx.Done():
@@ -466,13 +480,13 @@ func (x *xaiClient) streamWithParams(ctx context.Context, params openai.ChatComp
 						continue // Try again
 					}
 				}
-				
+
 				// No retry - send error
 				request.Clear()
 				eventChan <- ProviderEvent{Type: EventError, Error: streamErr}
 				return
 			}
-			
+
 			// Success - stream completed
 			if !hasError {
 				finishReason := x.finishReason(string(acc.ChatCompletion.Choices[0].FinishReason))
@@ -482,7 +496,7 @@ func (x *xaiClient) streamWithParams(ctx context.Context, params openai.ChatComp
 				if len(toolCalls) > 0 {
 					finishReason = message.FinishReasonToolUse
 				}
-				
+
 				eventChan <- ProviderEvent{
 					Type: EventComplete,
 					Response: &ProviderResponse{
@@ -497,7 +511,7 @@ func (x *xaiClient) streamWithParams(ctx context.Context, params openai.ChatComp
 			}
 		}
 	}()
-	
+
 	return eventChan
 }
 
@@ -523,9 +537,9 @@ func (x *xaiClient) logError(err error, params openai.ChatCompletionNewParams) {
 			debugFile, _ := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 			if debugFile != nil {
 				defer debugFile.Close()
-				
+
 				fmt.Fprintf(debugFile, "[%s] xAI Error: %v\n", time.Now().Format("15:04:05"), err)
-				
+
 				// Log xAI-specific content errors
 				var xaiErr *xaiContentError
 				if errors.As(err, &xaiErr) {
@@ -535,11 +549,11 @@ func (x *xaiClient) logError(err error, params openai.ChatCompletionNewParams) {
 					fmt.Fprintf(debugFile, "  - Content: %s\n", strings.TrimSpace(xaiErr.Content))
 					fmt.Fprintf(debugFile, "  - Model: %s\n", params.Model)
 				}
-				
+
 				// Log the request parameters for debugging
 				jsonParams, _ := json.Marshal(params)
 				fmt.Fprintf(debugFile, "[%s] xAI Request Params: %s\n", time.Now().Format("15:04:05"), string(jsonParams))
-				
+
 				// Log the full response body if available for standard errors
 				var apierr *openai.Error
 				if errors.As(err, &apierr) && apierr.Response != nil {
@@ -554,6 +568,12 @@ func (x *xaiClient) logError(err error, params openai.ChatCompletionNewParams) {
 // getConfig returns the current config
 func (x *xaiClient) getConfig() *config.Config {
 	return config.Get()
+}
+
+// isDebugMode returns true if global debug is enabled.
+func (x *xaiClient) isDebugMode() bool {
+	cfg := x.getConfig()
+	return cfg != nil && cfg.Debug
 }
 
 // getLogPath returns the path to the debug log file


### PR DESCRIPTION
## Summary
- check debug flag before writing to `/tmp/xai-stream-debug.log`
- add `isDebugMode()` helpers

## Testing
- `go test ./...` *(fails: config not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6875ee5b427083278e95c2dd13b5ca3c