### PR TITLE
Fix truncated line in CLAUDE documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,4 @@ This applies to ALL files: scripts, code, configs, etc. One file, one purpose.
 
 ## Documentation Guidelines
 
-- All generated documents unless otherwise instructed should default to be placed in `docs/`
+- All generated documents, unless otherwise instructed, should be placed in `docs/`.


### PR DESCRIPTION
## Summary
- restore the last bullet of the documentation guidelines in `CLAUDE.md`
- ensure file ends with a newline

## Testing
- `go test ./...` *(fails: config not loaded)*
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875ee19bed483279896ad34726f23a4